### PR TITLE
[Feat] Pls-98 : Implement see more hide review function

### DIFF
--- a/app/components-hj/leisure-detail/atoms/Button.tsx
+++ b/app/components-hj/leisure-detail/atoms/Button.tsx
@@ -7,7 +7,7 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   divStyle: string;
   buttonStyle: string;
   content: string;
-  linkHref?: string;
+  linkHref?: string | undefined;
 }
 // ButtonHTMLAttributes<HTMLButtonElement>를 extends하면
 // 기본적인 button의 attribute와 event등을 사용할 수 있음
@@ -16,12 +16,12 @@ export default function Button({
   divStyle,
   buttonStyle,
   content,
-  linkHref,
+  linkHref = '/',
   ...props
 }: Props) {
   return (
     <div className={divStyle}>
-      <Link href={linkHref ? linkHref : '/'}>
+      <Link href={linkHref}>
         <button className={buttonStyle} {...props}>
           {content}
         </button>

--- a/app/components-hj/leisure-detail/organisms/Header.tsx
+++ b/app/components-hj/leisure-detail/organisms/Header.tsx
@@ -4,10 +4,10 @@ import React from 'react';
 import Icon from '../atoms/Icon';
 
 type HeaderProps = {
-  title: string;
+  storeName: string | undefined;
 };
 
-export default function Header({ title }: HeaderProps) {
+export default function Header({ storeName }: HeaderProps) {
   return (
     <header className="flex items-center justify-between px-4 mt-6 mb-3 previous">
       <div className="flex items-center cursor-pointer w-9 h-9">
@@ -23,7 +23,7 @@ export default function Header({ title }: HeaderProps) {
         />
       </div>
       <p className="max-w-[240px] overflow-hidden text-xl font-bold text-center break-all title-txt text-ellipsis">
-        {title}
+        {storeName}
       </p>
       <div className="flex items-center cursor-pointer share w-9 h-9">
         <Icon

--- a/app/components-hj/leisure-detail/organisms/Review.tsx
+++ b/app/components-hj/leisure-detail/organisms/Review.tsx
@@ -42,8 +42,7 @@ const REVIEW_ARTICLE_DATA: IReviewList[] = [
       '/images/leisure-detail/test-profile-img.png',
     reviewWriterAge: 29,
     reviewWriterGender: 'MALE',
-    storeReviewContent:
-      '사장님이 너무 친절했어요. 그리고 시설도 너무 깨끗해요. 저희 집보다 깨끗한 것 같아요. 또 가고싶어요. 풍경도, 조식도 너무 만족스러웠어요!!!',
+    storeReviewContent: '더운 여름... 정말 행복했습니다',
     storeReviewRating: 5,
     storeReviewPhotoUrls: [
       { id: 1, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
@@ -51,7 +50,7 @@ const REVIEW_ARTICLE_DATA: IReviewList[] = [
       { id: 3, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
       { id: 4, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
     ],
-    createdAt: new Date().toLocaleDateString('ko-KR'),
+    createdAt: '2023-08-15T12:00:00.000Z',
   },
   {
     storeReviewId: '2',
@@ -61,7 +60,7 @@ const REVIEW_ARTICLE_DATA: IReviewList[] = [
     reviewWriterAge: 18,
     reviewWriterGender: 'FEMALE',
     storeReviewContent:
-      '사장님이 너무 친절했어요. 그리고 시설도 너무 깨끗해요. 저희 집보다 깨끗한 것 같아요. 또 가고싶어요. 풍경도, 조식도 너무 만족스러웠어요!!!',
+      '사장님이 너무 친절했어요. 그리고 시설도 너무 깨끗해요. 저희 집보다 깨끗한 것 같아요. 또 가고싶어요. 풍경도, 청결도도 너무 만족스러웠어요!!!',
     storeReviewRating: 4,
     storeReviewPhotoUrls: [
       { id: 1, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
@@ -69,7 +68,7 @@ const REVIEW_ARTICLE_DATA: IReviewList[] = [
       { id: 3, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
       { id: 4, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
     ],
-    createdAt: new Date().toLocaleDateString('ko-KR'),
+    createdAt: '2023-07-05T12:00:00.000Z',
   },
   {
     storeReviewId: '3',
@@ -79,14 +78,14 @@ const REVIEW_ARTICLE_DATA: IReviewList[] = [
     reviewWriterAge: 38,
     reviewWriterGender: 'FEMALE',
     storeReviewContent:
-      '사장님이 너무 친절했어요. 그리고 시설도 너무 깨끗해요. 저희 집보다 깨끗한 것 같아요. 또 가고싶어요. 풍경도, 조식도 너무 만족스러웠어요!!!',
-    storeReviewRating: 5,
+      '구명조끼나 튜브들 청소 좀 잘해주셨으면 좋겠어요. 거기서 일하시는 직원분들 중 누구는 친절하고 누구는 불친절하네요. 그래도 레저는 굉장히 익스트림하고 재밌었던 것 같습니다! 위험에 많이 신경써주시는 느낌이였어요. 주변 정돈만 잘해주시면 가격도 괜찮고 접근성도 좋아서 자주 갈 것 같습니다!! 주차장이 넓지 않으니 오시는 분들은 주변 주차장도 꼭 알아보시고 오는게 좋을 것 같아요.',
+    storeReviewRating: 3,
     storeReviewPhotoUrls: [
       { id: 1, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
       { id: 2, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
       { id: 3, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
       { id: 4, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
     ],
-    createdAt: new Date().toLocaleDateString('ko-KR'),
+    createdAt: '2022-09-29T12:00:00.000Z',
   },
 ];

--- a/app/components-hj/leisure-detail/organisms/ReviewArticle.tsx
+++ b/app/components-hj/leisure-detail/organisms/ReviewArticle.tsx
@@ -24,6 +24,7 @@ export default function ReviewArticle({
   storeReviewPhotoUrls,
 }: ArticleProps) {
   const [moreBtn, setMoreBtn] = useState(false);
+  const reviewLengthMinimum = 70;
 
   const starsCnt = new Array(storeReviewRating).fill(storeReviewRating);
   while (starsCnt.length < 5) {
@@ -87,24 +88,18 @@ export default function ReviewArticle({
       <Slide width="reviewWidth" gap="reviewGap" data={storeReviewPhotoUrls} />
 
       {/* review content */}
-      <div className="mb-8 review-content">
+      <div className="mb-8 review-content" onClick={() => setMoreBtn(!moreBtn)}>
         <p className="overflow-hidden break-all review-content__text content text-ellipsis">
-          {storeReviewContent.length > 70 && !moreBtn && (
-            <span
-              className="float-right text-sm more mt-[1.6rem] text-lightGrayTxt cursor-pointer"
-              onClick={() => setMoreBtn(true)}
-            >
+          {storeReviewContent.length > reviewLengthMinimum && !moreBtn && (
+            <span className="float-right text-sm more mt-[1.6rem] text-lightGrayTxt cursor-pointer">
               더보기
             </span>
           )}
           {storeReviewContent}
-          {storeReviewContent.length > 70 && moreBtn && (
-            <p
-              className="text-sm text-right cursor-pointer text-lightGrayTxt"
-              onClick={() => setMoreBtn(false)}
-            >
+          {storeReviewContent.length > reviewLengthMinimum && moreBtn && (
+            <span className="block text-sm text-right cursor-pointer text-lightGrayTxt">
               접기
-            </p>
+            </span>
           )}
         </p>
       </div>

--- a/app/components-hj/leisure-detail/organisms/ReviewArticle.tsx
+++ b/app/components-hj/leisure-detail/organisms/ReviewArticle.tsx
@@ -3,6 +3,8 @@
 import { IReviewList } from '@/app/types-hj/IStores';
 import Icon from '../atoms/Icon';
 import Slide from '../atoms/Slide';
+import { useState } from 'react';
+import RelativeTime from '@/app/libs-hj/utils/RelativeTime';
 
 interface ArticleProps extends IReviewList {
   dataIdx: number;
@@ -21,7 +23,12 @@ export default function ReviewArticle({
   storeReviewRating,
   storeReviewPhotoUrls,
 }: ArticleProps) {
+  const [moreBtn, setMoreBtn] = useState(false);
+
   const starsCnt = new Array(storeReviewRating).fill(storeReviewRating);
+  while (starsCnt.length < 5) {
+    starsCnt.push(0);
+  }
 
   return (
     <article className={`pb-6 pt-6 review-article`}>
@@ -42,19 +49,32 @@ export default function ReviewArticle({
               {starsCnt.map((v, i) => {
                 return (
                   <span key={i}>
-                    <Icon
-                      className="w-5 h-5 -m-[1px] text-cyanTxt"
-                      viewBox="0 0 20 20"
-                      fill="currentColor"
-                      pathD="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
-                    />
+                    {v === 0 ? (
+                      <Icon
+                        className="w-[1.1rem] h-[1.1rem] text-cyanTxt emptyStar"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        pathD="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"
+                      />
+                    ) : (
+                      <Icon
+                        className="w-5 h-5 -m-[1px] text-cyanTxt fillStar"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        pathD="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    )}
                   </span>
                 );
               })}
-              <span className="mx-3">{createdAt}</span>
+              <span className="mx-3">{RelativeTime(createdAt)}</span>
               <span>
                 {/* 10대, 20대로 바꾸기 */}
-                {`${reviewWriterAge.toString()[0]}0대`} /{' '}
+                {`${reviewWriterAge.toString()[0]}0대`}/
                 {reviewWriterGender === 'FEMALE' ? '여' : '남'}
               </span>
             </div>
@@ -69,16 +89,29 @@ export default function ReviewArticle({
       {/* review content */}
       <div className="mb-8 review-content">
         <p className="overflow-hidden break-all review-content__text content text-ellipsis">
-          <span className="float-right text-sm more mt-[1.6rem] text-lightGrayTxt cursor-pointer">
-            더보기
-          </span>
+          {storeReviewContent.length > 70 && !moreBtn && (
+            <span
+              className="float-right text-sm more mt-[1.6rem] text-lightGrayTxt cursor-pointer"
+              onClick={() => setMoreBtn(true)}
+            >
+              더보기
+            </span>
+          )}
           {storeReviewContent}
+          {storeReviewContent.length > 70 && moreBtn && (
+            <p
+              className="text-sm text-right cursor-pointer text-lightGrayTxt"
+              onClick={() => setMoreBtn(false)}
+            >
+              접기
+            </p>
+          )}
         </p>
       </div>
       {dataIdx === dataLength - 1 || <hr className="mt-12" />}
       <style jsx>{`
         .content {
-          display: -webkit-box;
+          display: ${moreBtn ? '' : '-webkit-box'};
           -webkit-line-clamp: 2;
           -webkit-box-orient: vertical;
         }

--- a/app/components-hj/leisure-detail/organisms/StoreInfo.tsx
+++ b/app/components-hj/leisure-detail/organisms/StoreInfo.tsx
@@ -4,9 +4,62 @@ import { useState } from 'react';
 import CEOInfo from './CEOInfo';
 import Icon from '../atoms/Icon';
 import Map from '../molecules/Map';
+import { IStores } from '@/app/types-hj/IStores';
 
-export default function StoreInfo() {
+interface Props extends IStores {
+  closingHours: string | undefined;
+}
+
+export default function StoreInfo({
+  storeStatus = 'CLOSING',
+  storeBusinessHours,
+  closingHours = '시간 정보 없음',
+}: Props) {
   const [show, setShow] = useState(false);
+
+  function dayName(dayOfWeek: string) {
+    let day = '';
+    switch (dayOfWeek) {
+      case 'MON':
+        day = '월';
+        break;
+      case 'TUE':
+        day = '화';
+        break;
+      case 'WED':
+        day = '수';
+        break;
+      case 'THU':
+        day = '목';
+        break;
+      case 'FRI':
+        day = '금';
+        break;
+      case 'SAT':
+        day = '토';
+        break;
+      case 'SUN':
+        day = '일';
+        break;
+    }
+    return day;
+  }
+
+  function currentStatue(storeStatus: string) {
+    let status = '';
+    switch (storeStatus) {
+      case 'OPENNING':
+        status = '영업 중';
+        break;
+      case 'CLOSING':
+        status = '휴업 중';
+        break;
+      case 'SHUT_DOWN':
+        status = '폐업 상태';
+        break;
+    }
+    return status;
+  }
 
   return (
     <section className="px-4 store-info">
@@ -23,10 +76,10 @@ export default function StoreInfo() {
               strokeLinejoin="round"
               pathD="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
             />
-            <span>영업 중</span>
+            <span>{currentStatue(storeStatus)}</span>
           </p>
           <div className="flex items-center bussiness-hours">
-            <p>오후 10:00까지</p>
+            <p>{closingHours}까지</p>
             <Icon
               className="flex items-center w-[1.2rem] h-[1.2rem] ml-1 cursor-pointer"
               fill="none"
@@ -42,18 +95,25 @@ export default function StoreInfo() {
         </div>
         {show && (
           <ul className="hours-list ml-[1.69rem] mb-5 text-sm">
-            {BUSINESS_HOURS_LIST.map(({ day, openHours, closeHours }) => {
-              return (
-                <li key={day} className="mb-[0.4rem]">
-                  <span className="mr-[3.2rem]">{day}</span>
-                  <span>
-                    {openHours === ''
-                      ? '휴무일'
-                      : `${openHours} - ${closeHours}`}
-                  </span>
-                </li>
-              );
-            })}
+            {storeBusinessHours?.map(
+              ({
+                dayOfWeek = '정보 없음',
+                openingHours,
+                closingHours,
+                businessHourStatus,
+              }) => {
+                return (
+                  <li key={dayOfWeek} className="mb-[0.4rem]">
+                    <span className="mr-[3.2rem]">{dayName(dayOfWeek)}</span>
+                    <span>
+                      {businessHourStatus === 'CLOSED'
+                        ? '휴무일'
+                        : `${openingHours} - ${closingHours}`}
+                    </span>
+                  </li>
+                );
+              }
+            )}
           </ul>
         )}
         {STORE_INFO.map(({ infoId, iconTag, content }) => {
@@ -108,14 +168,4 @@ const STORE_INFO = [
       'M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z',
     content: '경기 가평군 가평읍 북한강변로 274-22',
   },
-];
-
-const BUSINESS_HOURS_LIST = [
-  { day: '월', openHours: '', closeHours: '' },
-  { day: '화', openHours: '11:00 am', closeHours: '09:00 pm' },
-  { day: '수', openHours: '11:00 am', closeHours: '09:00 pm' },
-  { day: '목', openHours: '11:00 am', closeHours: '09:00 pm' },
-  { day: '금', openHours: '11:00 am', closeHours: '09:00 pm' },
-  { day: '토', openHours: '11:00 am', closeHours: '09:00 pm' },
-  { day: '일', openHours: '', closeHours: '' },
 ];

--- a/app/components-hj/leisure-detail/organisms/StorePost.tsx
+++ b/app/components-hj/leisure-detail/organisms/StorePost.tsx
@@ -4,17 +4,17 @@ import StorePostSlide from './StorePostSlide';
 import Icon from '../atoms/Icon';
 
 interface Props {
-  categoryName: string;
-  storeTitleContent: string;
-  storeReviewsCount: number;
-  totalRatingAverage: number;
+  categoryName: string | undefined;
+  storeName: string | undefined;
+  storeReviewCount: number | undefined;
+  totalRatingAverage: number | undefined;
 }
 
 export default function StorePost({
   categoryName,
-  storeTitleContent,
+  storeName,
   totalRatingAverage,
-  storeReviewsCount,
+  storeReviewCount,
 }: Props) {
   return (
     <section className="mb-10 overflow-hidden store-post">
@@ -22,7 +22,7 @@ export default function StorePost({
       <div className="px-4 store-title">
         <p className="mt-4 text-sm text-lightGrayTxt">{categoryName}</p>
         <div className="my-2 overflow-hidden text-lg break-all title-txt text-ellipsis">
-          {storeTitleContent}
+          {storeName}
         </div>
         <div className="flex text-sm rating-review-box">
           <div className="flex rating">
@@ -37,7 +37,7 @@ export default function StorePost({
             <span className="ml-1 mr-3 font-bold">{totalRatingAverage}</span>
           </div>
           <div className="reviewCnt">
-            <p>리뷰 {storeReviewsCount > 1000 ? '999+' : storeReviewsCount}</p>
+            <p>리뷰 {storeReviewCount > 1000 ? '999+' : storeReviewCount}</p>
           </div>
         </div>
       </div>

--- a/app/components-hj/leisure-detail/organisms/VisitorPost.tsx
+++ b/app/components-hj/leisure-detail/organisms/VisitorPost.tsx
@@ -10,10 +10,9 @@ export default function VisitorPost() {
 
       {/* visitor photo slide */}
       <Slide
-        imgUrl="/images/leisure-detail/test-visitor-img.jpeg"
         width="visitorWidth"
         gap="visitorGap"
-        data={[1, 2, 3, 4]}
+        data={VISITOR_POST_DATA.postPhotoUrl}
       />
 
       <Button
@@ -24,3 +23,13 @@ export default function VisitorPost() {
     </section>
   );
 }
+
+const VISITOR_POST_DATA = {
+  postId: '1',
+  postPhotoUrl: [
+    { id: 1, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
+    { id: 2, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
+    { id: 3, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
+    { id: 4, imgUrl: '/images/leisure-detail/test-visitor-img.jpeg' },
+  ],
+};

--- a/app/leisure-detail/page.tsx
+++ b/app/leisure-detail/page.tsx
@@ -10,11 +10,11 @@ import { IReviewSummerize, IStores } from '../types-hj/IStores';
 export default function LeisureDetail() {
   return (
     <div className="container relative max-w-md min-w-[360px] m-auto text-grayTxt mb-24">
-      <Header title={STORE_POST_DATA.storeTitleContent} />
+      <Header storeName={STORE_POST_DATA.storeName} />
       <StorePost
-        categoryName={STORE_POST_DATA.storeCategories.categoryName}
-        storeTitleContent={STORE_POST_DATA.storeTitleContent}
-        storeReviewsCount={STORE_POST_DATA.storeReviewCount}
+        categoryName={STORE_POST_DATA.storeCategories!.categoryName}
+        storeName={STORE_POST_DATA.storeName}
+        storeReviewCount={STORE_POST_DATA.storeReviewCount}
         totalRatingAverage={REVIEW_SUMMERIZE_DATA.totalRatingAverage}
       />
       <VisitorPost />
@@ -23,7 +23,11 @@ export default function LeisureDetail() {
       <Nav />
 
       {/* 레저 스토어 정보 */}
-      <StoreInfo />
+      <StoreInfo
+        storeStatus={STORE_POST_DATA.storeStatus}
+        storeBusinessHours={STORE_POST_DATA.storeBusinessHours}
+        closingHours={STORE_POST_DATA.storeBusinessHours![0].closingHours}
+      />
 
       {/* 리뷰 */}
       <Review />
@@ -50,21 +54,104 @@ const STORE_POST_DATA: IStores = {
     { id: 4, imgUrl: '/images/leisure-detail/test-slide-img1.jpeg' },
     { id: 5, imgUrl: '/images/leisure-detail/test-slide-img2.jpeg' },
   ],
-  storeName: '가평빠지월드',
+  storeName:
+    '포스트 제목입니다. 레저 제목입니다. 2줄까지만 보여주기로 합니다. 너무 길면 안됩니다. 레저의 제목이자 콘텐츠내용입니다. 가평빠지 좋아요. 더운 여름 핫해핫해',
   storeStatus: 'OPENNING',
   storeCategories: {
     categoryLevel: 2,
     categoryName: '수상레저',
   },
   storeAverageRating: 4.8,
-  storeReviewCount: 1024, // * ✅ 내가 임의로 추가. 나중에 추가되야함.
-  storeTitleContent:
-    '포스트 제목입니다. 레저 제목입니다. 2줄까지만 보여주기로 합니다. 너무 길면 안됩니다. 레저의 제목이자 콘텐츠내용입니다. 가평빠지 좋아요. 더운 여름 핫해핫해', // * ✅ 내가 임의로 추가. 나중에 추가되야함.
+  storeReviewCount: 1024, // * ✅ 내가 임의로 추가. 나중에 추가돼야함.
   storeBusinessHours: [
     // 오늘을 기준으로 일주일의 영업시간을 나타냅니다. 예를 들어, 오늘이 토요일이면 토, 일, 월, 화, 수, 목, 금 순으로 영업시간을 나열합니다.
     {
+      dayOfWeek: 'MON',
+      businessHourStatus: 'CLOSED',
+      // OPENED: 영업 하는 날 / CLOSED: 영업 쉬는 날
+      // CLOSED 일때는 openingHours, closingHours, breakTimeStart, breakTimeEnd는 모두 null로.
+      openingHours: '11:00', // (“HH:MM” 24시간 기준)
+      closingHours: '21:00', // (“HH:MM” 24시간 기준)
+      breakTimes: [
+        {
+          breakTimeStart: '11:00', // (“HH:MM” 24시간 기준)
+          breakTimeEnd: '14:00', // (“HH:MM” 24시간 기준)
+        },
+      ],
+    },
+    {
+      dayOfWeek: 'TUE',
+      businessHourStatus: 'OPENED',
+      // OPENED: 영업 하는 날 / CLOSED: 영업 쉬는 날
+      // CLOSED 일때는 openingHours, closingHours, breakTimeStart, breakTimeEnd는 모두 null로.
+      openingHours: '11:00', // (“HH:MM” 24시간 기준)
+      closingHours: '21:00', // (“HH:MM” 24시간 기준)
+      breakTimes: [
+        {
+          breakTimeStart: '11:00', // (“HH:MM” 24시간 기준)
+          breakTimeEnd: '14:00', // (“HH:MM” 24시간 기준)
+        },
+      ],
+    },
+    {
       dayOfWeek: 'WED',
       businessHourStatus: 'OPENED',
+      // OPENED: 영업 하는 날 / CLOSED: 영업 쉬는 날
+      // CLOSED 일때는 openingHours, closingHours, breakTimeStart, breakTimeEnd는 모두 null로.
+      openingHours: '11:00', // (“HH:MM” 24시간 기준)
+      closingHours: '21:00', // (“HH:MM” 24시간 기준)
+      breakTimes: [
+        {
+          breakTimeStart: '11:00', // (“HH:MM” 24시간 기준)
+          breakTimeEnd: '14:00', // (“HH:MM” 24시간 기준)
+        },
+      ],
+    },
+    {
+      dayOfWeek: 'THU',
+      businessHourStatus: 'OPENED',
+      // OPENED: 영업 하는 날 / CLOSED: 영업 쉬는 날
+      // CLOSED 일때는 openingHours, closingHours, breakTimeStart, breakTimeEnd는 모두 null로.
+      openingHours: '11:00', // (“HH:MM” 24시간 기준)
+      closingHours: '21:00', // (“HH:MM” 24시간 기준)
+      breakTimes: [
+        {
+          breakTimeStart: '11:00', // (“HH:MM” 24시간 기준)
+          breakTimeEnd: '14:00', // (“HH:MM” 24시간 기준)
+        },
+      ],
+    },
+    {
+      dayOfWeek: 'FRI',
+      businessHourStatus: 'OPENED',
+      // OPENED: 영업 하는 날 / CLOSED: 영업 쉬는 날
+      // CLOSED 일때는 openingHours, closingHours, breakTimeStart, breakTimeEnd는 모두 null로.
+      openingHours: '11:00', // (“HH:MM” 24시간 기준)
+      closingHours: '21:00', // (“HH:MM” 24시간 기준)
+      breakTimes: [
+        {
+          breakTimeStart: '11:00', // (“HH:MM” 24시간 기준)
+          breakTimeEnd: '14:00', // (“HH:MM” 24시간 기준)
+        },
+      ],
+    },
+    {
+      dayOfWeek: 'SAT',
+      businessHourStatus: 'OPENED',
+      // OPENED: 영업 하는 날 / CLOSED: 영업 쉬는 날
+      // CLOSED 일때는 openingHours, closingHours, breakTimeStart, breakTimeEnd는 모두 null로.
+      openingHours: '11:00', // (“HH:MM” 24시간 기준)
+      closingHours: '21:00', // (“HH:MM” 24시간 기준)
+      breakTimes: [
+        {
+          breakTimeStart: '11:00', // (“HH:MM” 24시간 기준)
+          breakTimeEnd: '14:00', // (“HH:MM” 24시간 기준)
+        },
+      ],
+    },
+    {
+      dayOfWeek: 'SUN',
+      businessHourStatus: 'CLOSED',
       // OPENED: 영업 하는 날 / CLOSED: 영업 쉬는 날
       // CLOSED 일때는 openingHours, closingHours, breakTimeStart, breakTimeEnd는 모두 null로.
       openingHours: '11:00', // (“HH:MM” 24시간 기준)

--- a/app/libs-hj/utils/RelativeTime.ts
+++ b/app/libs-hj/utils/RelativeTime.ts
@@ -1,0 +1,10 @@
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import 'dayjs/locale/ko';
+
+dayjs.locale('ko');
+dayjs.extend(relativeTime);
+
+export default function RelativeTime(dateString: string) {
+  return dayjs(dateString).fromNow();
+}

--- a/app/types-hj/IStores.ts
+++ b/app/types-hj/IStores.ts
@@ -1,38 +1,35 @@
 export interface IStores {
-  storeId: string;
-  storeImageUrls: { id: number; imgUrl: string }[]; // * ✅ 내가 임의로 객체타입 만듬
-  storeName: string;
-  storeStatus: 'OPENNING' | 'CLOSING' | 'SHUT_DOWN';
-  storeCategories: {
+  storeId?: string;
+  storeImageUrls?: { id: number; imgUrl: string }[]; // * ✅ 내가 임의로 객체타입 만듬
+  storeName?: string; // storeName이 storeContent
+  storeStatus?: 'OPENNING' | 'CLOSING' | 'SHUT_DOWN';
+  storeCategories?: {
     categoryLevel: number;
     categoryName: string;
   };
-  storeAverageRating: number;
-  storeReviewCount: number;
-  storeTitleContent: string; // * ✅ 내가 임의로 객체타입 만듬
-  storeBusinessHours: [
-    {
-      // 오늘을 기준으로 일주일의 영업시간을 나타냅니다. 예를 들어, 오늘이 토요일이면 토, 일, 월, 화, 수, 목, 금 순으로 영업시간을 나열합니다.
+  storeAverageRating?: number;
+  storeReviewCount?: number;
+  storeBusinessHours?: {
+    // 오늘을 기준으로 일주일의 영업시간을 나타냅니다. 예를 들어, 오늘이 토요일이면 토, 일, 월, 화, 수, 목, 금 순으로 영업시간을 나열합니다.
 
-      dayOfWeek: 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'SUN';
-      businessHourStatus: 'OPENED' | 'CLOSED';
-      // OPENED: 영업 하는 날 / CLOSED: 영업 쉬는 날
-      // CLOSED 일때는 openingHours, closingHours, breakTimeStart, breakTimeEnd는 모두 null로.
-      openingHours: string; // (“HH:MM” 24시간 기준)
-      closingHours: string; // (“HH:MM” 24시간 기준)
-      breakTimes: [
-        {
-          breakTimeStart: string; // (“HH:MM” 24시간 기준)
-          breakTimeEnd: string; // (“HH:MM” 24시간 기준)
-        }
-      ];
-    }
-  ];
-  storeAddress: string;
-  storeLatitude: number;
-  storeLongitude: number;
-  storePhone: string;
-  storeReservationUrl: string;
+    dayOfWeek?: 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'SUN';
+    businessHourStatus?: 'OPENED' | 'CLOSED';
+    // OPENED: 영업 하는 날 / CLOSED: 영업 쉬는 날
+    // CLOSED 일때는 openingHours, closingHours, breakTimeStart, breakTimeEnd는 모두 null로.
+    openingHours?: string; // (“HH:MM” 24시간 기준)
+    closingHours?: string; // (“HH:MM” 24시간 기준)
+    breakTimes?: [
+      {
+        breakTimeStart: string; // (“HH:MM” 24시간 기준)
+        breakTimeEnd: string; // (“HH:MM” 24시간 기준)
+      }
+    ];
+  }[];
+  storeAddress?: string;
+  storeLatitude?: number;
+  storeLongitude?: number;
+  storePhone?: string;
+  storeReservationUrl?: string;
 }
 
 export interface IReviewSummerize {
@@ -58,7 +55,7 @@ export interface IReviewList {
 
 export interface IVisitorPost {
   postId: string;
-  postPhotoUrl: string[];
+  postPhotoUrl: { id: number; imgUrl: string }[]; // * ✅ 내가 임의로 객체타입 만듬
 }
 
 export interface ICEOInfo {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react-dom": "18.2.7",
     "autoprefixer": "10.4.14",
     "axios": "^1.4.0",
+    "dayjs": "^1.11.9",
     "eslint": "8.45.0",
     "eslint-config-next": "13.4.10",
     "jotai": "^2.2.3",


### PR DESCRIPTION
## :: 리뷰글 더보기/접기 기능 구현

### 구현 사항 설명

**✨ Add implement see more hide review function ```ReviewArticle.tsx```**
- 리뷰 콘텐츠 더보기 누르면 전체글 다 보이고, 접기 누르면 리뷰글이 2줄이상 생략되도록 기능 구현
- ```useState```로 boolean 상태값을 관리하여, 더보기를 누르면 2줄이상 생략되는 style을 무력화시키고 접기버튼이 나타나도록 구현했다. 
- 추가로 리뷰글이 ```70자``` 이상을 넘지않으면, 더보기/접기 버튼 둘다 보이지 않도록 구현했다.

**♻️ Refactor**

```ReviewArticle.tsx```
- review rating 별점따라, **채워진 별**과 **빈 별**이 알맞게 렌더링될 수 있도록 리팩토링

```RelativeTims.ts```
- utils 폴더 생성
- 리뷰작성일자와 현재와의 오차일을 구하기 위하여 ```dayjs``` 라는 라이브러리를 활용하였다.
- 한국어로 설정해주고, ```dayjs``` 내장 플러그인 ```relativeTime``` 기능을 활용하여 구현하였다.

**♻️ Refactor 2**

```ReviewArticle.tsx```
- 리뷰 두줄 이하의 글 개수인 70을, ```reviewLengthMinimum``` 으로 상수변수 처리
- 더보기/접기 클릭이벤트를 리뷰글을 감싸고 있는 div태그 자체에 달아, 사용자의 클릭범위를 넓힘
- p태그 내에 p태그를 중첩시켜, validateDOMNesting warning 이슈가 생겼다.
-> 하위 <p>태그를 인라인 레벨 요소인 <span>태그로 바꿔주었다.

```StoreInfo.tsx```
- API spec의 데이터 형식들을, 프론트 딴에서 사용자에게 보여질 알맞은 텍스트로 변환시켜주는 function들 생성. switch문을 사용하였다.

```StorePost.tsx```
- storeName이 곧 store content가 되므로 storeName을 올바른 위치들로 배치 및 수정

<br/>

### 코드 기록
_기록인 만큼 코드는 최대한 간추려서 보기좋게 정리하였습니다. 상세한 코드는 실제 코드를 참고해주세요._
- 리뷰 더보기/접기
```typescript
{content.length > 70 && !moreBtn && (
  <span onClick={() => setMoreBtn(true)}> 더보기 </span>
)}
  {content}
{content.length > 70 && moreBtn && (
  <p onClick={() => setMoreBtn(false)}> 접기 </p>
  // 접기버튼을 p태그로 한 이유는 더보기 버튼과 다르게 리뷰글을 전체 다 보여줘야 하므로,
  // 리뷰글과 겹치도록 inline 태그를 사용할 이유가 없었다. (style적으로도 마찬가지)
)}
```

- 별점 숫자에 맞게 렌더링
```typescript
const starsCnt = new Array(storeReviewRating).fill(storeReviewRating);
  while (starsCnt.length < 5) {
    starsCnt.push(0);
  }

{starsCnt.map((v, i) => {
  return ( <span key={i}> {v === 0 ? ( <Icon emptyStar … /> ) : ( <Icon fillStar … /> )}</span> );
   })}
```
<br/>

### 브랜치 회고
- 더보기/접기 버튼 기능을 구현했는데, 코드가 좀 지저분해보이기도 하고 가독성이 떨어진다. 좀 더 코드를 간결하게 줄일 방법이 없을까..?! 
- Next의 Hydration과, html중첩태그불가 이슈에 대해 블로그 정리를 해야할듯
<br/>